### PR TITLE
fix: Set correct github url in footer

### DIFF
--- a/frontend/components/PageFooter.vue
+++ b/frontend/components/PageFooter.vue
@@ -9,7 +9,7 @@
 
             <div class="text-zinc-600 hover:text-indigo-400 transition-colors">
                 <a
-                    href="https://github.com/WlanKabL/cold-blood-stream"
+                    href="https://github.com/WlanKabL/cold-blood-cast"
                     target="_blank"
                     rel="noopener"
                 >


### PR DESCRIPTION
This pull request includes a small update to the `frontend/components/PageFooter.vue` file. The change updates the GitHub repository link in the footer to point to the correct repository, `cold-blood-cast`, instead of `cold-blood-stream`.